### PR TITLE
Fix infinite loader fetch loop and clean API URL

### DIFF
--- a/app/action.tsx
+++ b/app/action.tsx
@@ -3,7 +3,7 @@
 import AnimeCard, { AnimeProp } from "@/components/AnimeCard";
 
 export const fetchAnime = async (page : number) => {
-    const response = await fetch(`https://shikimori.one/api/animes?page=${page}&limit=8&order=ranked `);
+    const response = await fetch(`https://shikimori.one/api/animes?page=${page}&limit=8&order=ranked`);
 
     const data = await response.json();
 

--- a/components/LoadMore.tsx
+++ b/components/LoadMore.tsx
@@ -15,16 +15,14 @@ function LoadMore() {
   const { ref, inView } = useInView();
   const [data, setData] = useState<AnimeCard[]>([]);
 
-
   useEffect(() => {
-    if(inView) {
-      fetchAnime(page)
-      .then((res) => {
-        setData([...data, ...res]);
+    if (inView) {
+      fetchAnime(page).then((res) => {
+        setData((prev) => [...prev, ...res]);
         page++;
       });
     }
-  }, [inView, data]);
+  }, [inView]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- fix repeated fetch loop by removing `data` dependency and using functional update in `LoadMore`
- remove stray space from anime API URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898929224d48330965ba16fcd28a823